### PR TITLE
Don't use xformers nor fp16 in AMD GPUs

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -203,6 +203,8 @@ def get_autocast_device(dev):
 def xformers_enabled():
     if vram_state == CPU:
         return False
+    if torch.cuda.get_device_properties("cuda").name == "AMD":
+        return False
     return XFORMERS_IS_AVAILBLE
 
 
@@ -267,6 +269,9 @@ def should_use_fp16():
 
     props = torch.cuda.get_device_properties("cuda")
     if props.major < 7:
+        return False
+    
+    if "AMD" in props.name:
         return False
 
     #FP32 is faster on those cards?


### PR DESCRIPTION
Don't use xformers nor fp16 in AMD GPUs (not supported by them). Example name:

```
In [8]: torch.cuda.get_device_properties("cuda").name
Out[8]: 'AMD Radeon RX 5700 XT'
```